### PR TITLE
Wire component-based search into the main Han Nom dictionary search

### DIFF
--- a/src/app/[locale]/tools/han-nom-dictionaries/general/Entry.tsx
+++ b/src/app/[locale]/tools/han-nom-dictionaries/general/Entry.tsx
@@ -10,6 +10,10 @@ import EntryTaberd from "../taberd/Entry";
 import EntryNDTD from "../nhat-dung-thuong-dam/Entry";
 
 const merriweather = Merriweather({ weight: "300", subsets: ["vietnamese"] });
+// Use font-family name directly — NomNaTong is already loaded by DictionarySearchBar
+// on this page, avoiding a second localFont call in a client component which causes
+// server/client hydration mismatches.
+const nomNaTongStyle = { fontFamily: "var(--font-nom-na-tong), serif" } as const;
 
 interface GeneralDictionaryData {
   tdcndg: {
@@ -20,6 +24,7 @@ interface GeneralDictionaryData {
   qatd: any[];
   taberd: any[];
   ndtd: any[];
+  componentMatches?: string[];
 }
 
 function scrollToSource(event: MouseEvent<HTMLAnchorElement>, id: string) {
@@ -95,8 +100,52 @@ export default function Entry({
     },
   ].filter((section) => section.hasResults);
 
+  const componentMatches = entry.componentMatches ?? [];
+  const queryChars =
+    componentMatches.length > 0
+      ? Array.from(query).filter((ch) => {
+          const cp = ch.codePointAt(0);
+          if (cp === undefined) return false;
+          return (
+            (cp >= 0x4e00 && cp <= 0x9fff) ||
+            (cp >= 0x3400 && cp <= 0x4dbf) ||
+            (cp >= 0x20000 && cp <= 0x2ebef) ||
+            (cp >= 0x30000 && cp <= 0x323af) ||
+            (cp >= 0xf900 && cp <= 0xfaff)
+          );
+        })
+      : [];
+
   return (
     <div className="space-y-8">
+      {componentMatches.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <div
+            className={`text-lg text-branding-brown mb-3 ${merriweather.className}`}
+          >
+            {locale === "en"
+              ? `Characters with components ${queryChars
+                  .map((ch) => `[${ch}]`)
+                  .join("")}`
+              : `Chữ có các thành phần ${queryChars
+                  .map((ch) => `[${ch}]`)
+                  .join("")}`}
+          </div>
+          <div className="flex flex-wrap gap-4 text-3xl" style={nomNaTongStyle}>
+            {componentMatches.map((ch) => (
+              <Link
+                key={ch}
+                href={`/tools/han-nom-dictionaries/general?q=${encodeURIComponent(
+                  ch
+                )}`}
+                className="hover:text-branding-brown transition-colors"
+              >
+                {ch}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
       {sourceSections.length > 0 && (
         <div className="lg:hidden bg-white rounded-lg border border-gray-200 overflow-hidden">
           <div className="p-6 border-b border-gray-200">

--- a/src/app/[locale]/tools/han-nom-dictionaries/general/page.tsx
+++ b/src/app/[locale]/tools/han-nom-dictionaries/general/page.tsx
@@ -20,6 +20,7 @@ interface GeneralDictionaryData {
   qatd: any[];
   taberd: any[];
   ndtd: any[];
+  componentMatches?: string[];
 }
 
 export default async function DictionaryPage({
@@ -47,7 +48,8 @@ export default async function DictionaryPage({
       (data.giupdoc && data.giupdoc.length > 0) ||
       (data.qatd && data.qatd.length > 0) ||
       (data.taberd && data.taberd.length > 0) ||
-      (data.ndtd && data.ndtd.length > 0));
+      (data.ndtd && data.ndtd.length > 0) ||
+      (data.componentMatches && data.componentMatches.length > 0));
 
   // Combine all headwords from different dictionaries for lookup
   const combinedHeadwords = Array.from(

--- a/src/app/api/han-nom-dictionary/all/dictionary/route.tsx
+++ b/src/app/api/han-nom-dictionary/all/dictionary/route.tsx
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { parseStringPromise } from "xml2js";
 import db from "@/lib/db";
+import { findCharsByComponents, isCJKChar } from "@/lib/han-nom/componentsIndex";
 
 export async function GET(request) {
   try {
@@ -10,6 +11,15 @@ export async function GET(request) {
 
     if (!query) {
       return NextResponse.json({ error: "Missing query" }, { status: 400 });
+    }
+
+    // Component-based search: if query is 2+ CJK chars, find characters with those components
+    let componentMatches: string[] = [];
+    const queryChars = Array.from(query);
+    const allCJK =
+      queryChars.length >= 2 && queryChars.every((ch) => isCJKChar(ch));
+    if (allCJK) {
+      componentMatches = findCharsByComponents(query);
     }
 
     // Tu Dien Chu Nom Dan Giai
@@ -149,6 +159,7 @@ export async function GET(request) {
         qatd: meaning || [],
         taberd: taberdData || [],
         ndtd: ndtdData || [],
+        componentMatches,
       },
       { status: 200 }
     );


### PR DESCRIPTION
## What

Searching a 2+ CJK-character query (e.g. 天上) in the **general** Han–Nôm dictionary now returns characters that **share those components**, matching the behavior that already existed in `albert-dictionaryupdate`.

## Why

Previously, a multi-character component query that didn't match any headword in the five source dictionaries (Tu dien chu Nom dan giai, Giup doc Nom va Han Viet, QATD, Taberd, NDTD) fell through to a "no result" dead end — even though component matches existed. The general search ignored component matches entirely.

## How

- `api/han-nom-dictionary/all/dictionary/route.tsx` — computes `componentMatches` via `findCharsByComponents` and includes it in the response.
- `general/page.tsx` — includes `componentMatches` in the `hasResults` check so the page renders results instead of "no result".
- `general/Entry.tsx` — renders the matched characters as clickable links under a "Characters with components […]" heading.

## Testing

Ran the dev server against this branch and queried `天上`:
- API returns `componentMatches` with 2 entries; all five traditional dictionaries return 0 for that query.
- The page renders the "Characters with components [天][上]" section with the matched characters as links, instead of "no result".

Single clean commit on top of `dev`.