### PR TITLE
feat: merge page title into the breadcrumb header

### DIFF
--- a/src/components/common/PageHeader.tsx
+++ b/src/components/common/PageHeader.tsx
@@ -1,37 +1,27 @@
-"use client";
 import type { ReactNode } from "react";
-import { useTranslations } from "next-intl";
-import { Merriweather } from "next/font/google";
 import BreadcrumbAndSearchBar from "@/components/layout/BreadcrumbAndSearchBar";
 import { Separator } from "@/components/ui/separator";
 
-const merriweather = Merriweather({ weight: "300", subsets: ["vietnamese"] });
-
 export function PageHeader({
-  title,
   subtitle,
   breadcrumbItems,
   locale,
 }: {
-  title: ReactNode;
+  // Kept for call-site compatibility; the title now renders as the current
+  // (last) breadcrumb crumb rather than a separate headline.
+  title?: ReactNode;
   subtitle: ReactNode;
   breadcrumbItems: { label: string; href?: string }[];
   locale: string;
 }) {
-  const t = useTranslations();
   return (
     <div className=" w-full">
+      {/* The last breadcrumb crumb doubles as the page title (see emphasizeCurrent). */}
       <BreadcrumbAndSearchBar
         locale={locale}
         breadcrumbItems={breadcrumbItems}
+        emphasizeCurrent
       />
-
-      {/* Headline */}
-      <div
-        className={`${merriweather.className} text-branding-black text-[32px]`}
-      >
-        {title}
-      </div>
 
       {/* Subheadline */}
       <div

--- a/src/components/layout/BreadcrumbAndSearchBar.tsx
+++ b/src/components/layout/BreadcrumbAndSearchBar.tsx
@@ -9,7 +9,14 @@ import {
 
 import { House } from "lucide-react";
 
-export default function BreadcrumbAndSearchBar({ locale, breadcrumbItems }) {
+export default function BreadcrumbAndSearchBar({
+  locale,
+  breadcrumbItems,
+  // When true, the current (last) crumb doubles as the page title: rendered a
+  // little larger than the rest of the breadcrumb. Used by PageHeader so the
+  // title lives in the breadcrumb instead of a separate headline below it.
+  emphasizeCurrent = false,
+}) {
   return (
     <div className="mb-10 mt-16">
       <Breadcrumb>
@@ -31,7 +38,13 @@ export default function BreadcrumbAndSearchBar({ locale, breadcrumbItems }) {
             </BreadcrumbList>
           ))}
           <BreadcrumbItem>
-            <BreadcrumbPage>
+            <BreadcrumbPage
+              className={
+                emphasizeCurrent
+                  ? "text-xl font-semibold text-branding-black"
+                  : undefined
+              }
+            >
               {breadcrumbItems.slice(-1)[0].label}
             </BreadcrumbPage>
           </BreadcrumbItem>


### PR DESCRIPTION
The shared PageHeader rendered a full breadcrumb ending in the current page plus a separate 32px headline with the same text, duplicating the page name (e.g. "/ Collections" then "Collections" below).

Drop the separate headline and instead render the current (last) breadcrumb crumb as the title — larger and bolder than the rest of the breadcrumb — via a new opt-in `emphasizeCurrent` prop on BreadcrumbAndSearchBar. Applies to every PageHeader page; components that use BreadcrumbAndSearchBar directly are unaffected (prop defaults off).