### PR TITLE
content: link the Hán-Nôm Institute, and add two journals to the periodicals list

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -557,7 +557,7 @@
       "tap-chi-han-nom": {
         "name": "Tạp chí Hán Nôm",
         "description": "The primary scholarly journal of the Institute of Sino-Nôm Studies in Hanoi, featuring research on manuscripts, linguistics, and historical texts.",
-        "url": "http://www.hannom.org.vn/web/tchn/data/8700f5f0"
+        "url": "https://vjol.info.vn/hannom/index/"
       },
       "befeo": {
         "name": "BEFEO",
@@ -568,6 +568,16 @@
         "name": "Journal of Vietnamese Studies",
         "description": "A peer-reviewed academic journal published by the University of California Press, covering all aspects of Vietnamese history, culture, and society.",
         "url": "https://online.ucpress.edu/jvs"
+      },
+      "tap-chi-ngon-ngu": {
+        "name": "Tạp chí Ngôn ngữ",
+        "description": "The journal of the Institute of Linguistics at the Vietnam Academy of Social Sciences, publishing research on the Vietnamese language and linguistics. Issues are hosted on Vietnam Journals Online (VJOL).",
+        "url": "https://vjol.info.vn/ngonngu/en/index/"
+      },
+      "tap-chi-nghien-cuu-phat-hoc": {
+        "name": "Tạp chí Nghiên cứu Phật học",
+        "description": "The journal of the Vietnam Buddhist Sangha, covering Buddhist history, doctrine, and the temples and textual heritage that preserve much of Vietnam's Hán-Nôm corpus.",
+        "url": "https://tapchinghiencuuphathoc.vn/"
       }
     }
   },

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -558,7 +558,7 @@
       "tap-chi-han-nom": {
         "name": "Tạp chí Hán Nôm",
         "description": "Tạp chí học thuật chính của Viện Nghiên cứu Hán Nôm, đăng tải các nghiên cứu về văn bản, ngôn ngữ và lịch sử.",
-        "url": "http://www.hannom.org.vn/web/tchn/data/8700f5f0"
+        "url": "https://vjol.info.vn/hannom/index/"
       },
       "befeo": {
         "name": "BEFEO",
@@ -569,6 +569,16 @@
         "name": "Journal of Vietnamese Studies",
         "description": "Tạp chí học thuật được bình duyệt bởi Đại học California, bao gồm tất cả các khía cạnh của lịch sử, văn hóa và xã hội Việt Nam.",
         "url": "https://online.ucpress.edu/jvs"
+      },
+      "tap-chi-ngon-ngu": {
+        "name": "Tạp chí Ngôn ngữ",
+        "description": "Tạp chí của Viện Ngôn ngữ học thuộc Viện Hàn lâm Khoa học xã hội Việt Nam, đăng tải các nghiên cứu về tiếng Việt và ngôn ngữ học. Các số được lưu trữ trên Vietnam Journals Online (VJOL).",
+        "url": "https://vjol.info.vn/ngonngu/en/index/"
+      },
+      "tap-chi-nghien-cuu-phat-hoc": {
+        "name": "Tạp chí Nghiên cứu Phật học",
+        "description": "Tạp chí của Giáo hội Phật giáo Việt Nam, đăng tải các nghiên cứu về lịch sử, giáo lý Phật giáo cùng di sản chùa chiền và thư tịch — nơi lưu giữ phần lớn kho tàng Hán-Nôm của Việt Nam.",
+        "url": "https://tapchinghiencuuphathoc.vn/"
       }
     }
   },

--- a/src/app/[locale]/research/han-nom/external-archives/page.tsx
+++ b/src/app/[locale]/research/han-nom/external-archives/page.tsx
@@ -82,17 +82,18 @@ export default async function ExternalArchivesPage({
 
   const physicalArchives = [
     {
+      name: isVi ? "Viện Nghiên cứu Hán-Nôm" : "Institute of Sino-Nôm Studies",
+      description: isVi
+        ? "Các danh mục thẻ và hồ sơ thư mục đã được số hóa từ Viện Nghiên cứu Hán-Nôm tại Hà Nội."
+        : "Digitized card catalogs and bibliographic records from the Institute of Sino-Nôm Studies in Hanoi.",
+      url: "https://hannom.vass.gov.vn/di-san-han-nom",
+    },
+    {
       name: "BULAC",
       description: isVi
         ? "Thư viện Đại học về Ngôn ngữ và Văn minh: Danh mục nghiên cứu toàn diện cho các bộ sưu tập tiếng Việt và Hán-Nôm phong phú tại Pháp."
         : "Bibliothèque universitaire des langues et civilisations: Comprehensive research catalog for extensive Vietnamese and Hán-Nôm collections in France.",
       url: "https://www.bulac.fr/",
-    },
-    {
-      name: isVi ? "Viện Nghiên cứu Hán-Nôm" : "Institute of Sino-Nôm Studies",
-      description: isVi
-        ? "Các danh mục thẻ và hồ sơ thư mục đã được số hóa từ Viện Nghiên cứu Hán-Nôm tại Hà Nội."
-        : "Digitized card catalogs and bibliographic records from the Institute of Sino-Nôm Studies in Hanoi.",
     },
     {
       name: isVi ? "Thư viện Quốc gia Việt Nam" : "National Library of Vietnam",

--- a/src/app/[locale]/research/han-nom/periodicals/page.tsx
+++ b/src/app/[locale]/research/han-nom/periodicals/page.tsx
@@ -29,14 +29,24 @@ export default async function PeriodicalsPage({
       url: t("Periodicals.list.jvs.url"),
     },
     {
+      name: t("Periodicals.list.tap-chi-han-nom.name"),
+      description: t("Periodicals.list.tap-chi-han-nom.description"),
+      url: t("Periodicals.list.tap-chi-han-nom.url"),
+    },
+    {
       name: t("Periodicals.list.befeo.name"),
       description: t("Periodicals.list.befeo.description"),
       url: t("Periodicals.list.befeo.url"),
     },
     {
-      name: t("Periodicals.list.tap-chi-han-nom.name"),
-      description: t("Periodicals.list.tap-chi-han-nom.description"),
-      url: t("Periodicals.list.tap-chi-han-nom.url"),
+      name: t("Periodicals.list.tap-chi-ngon-ngu.name"),
+      description: t("Periodicals.list.tap-chi-ngon-ngu.description"),
+      url: t("Periodicals.list.tap-chi-ngon-ngu.url"),
+    },
+    {
+      name: t("Periodicals.list.tap-chi-nghien-cuu-phat-hoc.name"),
+      description: t("Periodicals.list.tap-chi-nghien-cuu-phat-hoc.description"),
+      url: t("Periodicals.list.tap-chi-nghien-cuu-phat-hoc.url"),
     },
   ];
   const category = { resources: periodicals };


### PR DESCRIPTION
External archives: the Viện Nghiên cứu Hán-Nôm entry already carried its description but had no url, so ResourceList rendered the name as plain text. It now links to the Institute's digital heritage catalogue, and moves to the head of the physical-archives list — it is the holding institution most readers of this page are looking for.

  https://hannom.vass.gov.vn/di-san-han-nom

Periodicals:

  - Tạp chí Hán Nôm moves to second, after the Journal of Vietnamese Studies, and its link changes to the VJOL mirror. The old address, hannom.org.vn, 301s to hannom.vass.gov.vn, which does not connect at all; the https form of that path 404s. The VJOL copy answers 200 directly. https://vjol.info.vn/hannom/index/
  - Tạp chí Ngôn ngữ, the Institute of Linguistics' journal, added at the foot. https://vjol.info.vn/ngonngu/en/index/
  - Tạp chí Nghiên cứu Phật học, published under the Vietnam Buddhist Sangha, added after it. Its subject matter belongs here: the temples and their textual heritage hold much of the surviving Hán-Nôm corpus. https://tapchinghiencuuphathoc.vn/

Both journal names stay in Vietnamese in the English messages, matching how Tạp chí Hán Nôm was already handled.